### PR TITLE
静的サイト生成時のURLパースエラーを修正

### DIFF
--- a/app/server/utils/postCache.ts
+++ b/app/server/utils/postCache.ts
@@ -69,8 +69,8 @@ class PostCache {
 			});
 
 			const html = await marked.parse(content);
-			const path = `${filename}.md`.replace(
-				/(\d+)-(\d+)-(\d+)-([\w|-]+)\.md/,
+			const path = filename.replace(
+				/(\d+)-(\d+)-(\d+)-([\w|-]+)/,
 				"/$1/$2/$3/$4",
 			);
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,7 +2,7 @@ import { readdirSync } from "node:fs";
 
 const posts = readdirSync("./posts");
 const routes = posts.map((p) =>
-	p.replace(/(\d+)-(\d+)-(\d+)-([\w|-]+)\.md/, "$1/$2/$3/$4"),
+	p.replace(/(\d+)-(\d+)-(\d+)-([\w|-]+)\.md/, "/posts/$1/$2/$3/$4"),
 );
 
 export default defineNuxtConfig({


### PR DESCRIPTION
## 概要
`pnpm generate`実行時に発生していた「Failed to parse URL」エラーを修正しました。

## 問題
Nitroのプリレンダリング時に、相対パス（例：`2014/03/26/creators-meet-up-11`）をURLとして解析しようとして失敗していました。

## 修正内容
1. **nuxt.config.ts**: `generate.routes`の生成ルートに`/posts`プレフィックスを追加
   - 修正前: `"$1/$2/$3/$4"`
   - 修正後: `"/posts/$1/$2/$3/$4"`

2. **postCache.ts**: ファイル名から正しくパスを生成するよう修正
   - 不要な`.md`の追加を削除
   - 正規表現から`.md`部分を削除

## テスト計画
- [x] `pnpm generate`が正常に完了することを確認
- [x] 全48ルートが正しくプリレンダリングされることを確認
- [x] 生成された静的サイトが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)