### PR TITLE
pnpm generateでプロセスが終了しない問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
         run: pnpm generate
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: .output/public
 
   deploy:
     needs: build

--- a/app/server/utils/postCache.ts
+++ b/app/server/utils/postCache.ts
@@ -21,14 +21,20 @@ class PostCache {
 	private isWatching = false;
 
 	private async initializeWatcher() {
-		if (this.isWatching) return;
+		// Only watch files in development mode
+		if (!process.dev || this.isWatching) return;
 		this.isWatching = true;
 
 		try {
 			const watcher = watch("./posts");
-			for await (const event of watcher) {
-				this.invalidateCache();
-			}
+			// Use non-blocking approach
+			(async () => {
+				for await (const event of watcher) {
+					this.invalidateCache();
+				}
+			})().catch((error) => {
+				console.warn("Watcher error:", error);
+			});
 		} catch (error) {
 			console.warn("Could not watch posts directory:", error);
 		}


### PR DESCRIPTION
## 概要
CI環境で`pnpm generate`実行時にプロセスが終了しない問題を修正しました。

## 問題の原因
`app/server/utils/postCache.ts`の`initializeWatcher()`メソッドで、ファイル監視のための`for await`ループが無限に実行されていました。

```typescript
const watcher = watch("./posts");
for await (const event of watcher) {
    this.invalidateCache();
}
```

`fs.promises.watch()`は終了しないAsyncIterableを返すため、このループは永続的に実行され続け、プロセスが終了できませんでした。

## 修正内容

### 1. ファイル監視の制限
開発モードでのみファイル監視を有効化するように修正：
```typescript
// Only watch files in development mode
if (\!process.dev || this.isWatching) return;
```

### 2. ノンブロッキング実行
ファイル監視をノンブロッキングで実行するように変更：
```typescript
(async () => {
    for await (const event of watcher) {
        this.invalidateCache();
    }
})().catch((error) => {
    console.warn("Watcher error:", error);
});
```

### 3. GitHub Actionsの修正
出力パスを正しいディレクトリに修正：
- 修正前: `path: dist`
- 修正後: `path: .output/public`

## テスト計画
- [x] ローカルで`pnpm generate`が正常に完了することを確認
- [x] プロセスが正常に終了することを確認
- [ ] CI環境でのビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)