### PR TITLE
Fix tag filter persistence on page reload

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -8,24 +8,27 @@ const { data: allPosts } = await useFetch("/api/posts");
 const { data: allTags } = await useFetch("/api/tags");
 
 const tag = computed(() => route.query.tag);
+const selectedTag = ref(route.query.tag || '');
 
 const tagOptions = computed(
-	(): { label: string; value: string; selected: boolean }[] =>
+	(): { label: string; value: string }[] =>
 		[undefined, ...allTags.value].map((t) => ({
 			label: t || "未選択",
 			value: t || "",
-			selected: t === tag.value,
 		})),
 );
 
-function onChangeTag(event: Event) {
-	const value = event.target.value;
+function onChangeTag() {
 	router.push({
 		query: {
-			tag: value ? value : undefined,
+			tag: selectedTag.value ? selectedTag.value : undefined,
 		},
 	});
 }
+
+watch(() => route.query.tag, (newTag) => {
+	selectedTag.value = newTag || '';
+});
 
 useHead(() => ({
 	link: [
@@ -40,8 +43,8 @@ useHead(() => ({
 <template>
 	<div class="flex gap-x-2 items-center px-6 sm:px-12 my-6">
 		<label for="category-select" class="font-bold">絞り込みタグ:</label>
-		<select id="category-select" class="p-2 bg-gray-100 border border-gray-400 dark:text-gray-900" @change="onChangeTag">
-			<option v-for="(option, i) in tagOptions" :key="i" :value="option.value" :selected="option.selected">{{ option.label }}</option>
+		<select id="category-select" class="p-2 bg-gray-100 border border-gray-400 dark:text-gray-900" v-model="selectedTag" @change="onChangeTag">
+			<option v-for="(option, i) in tagOptions" :key="i" :value="option.value">{{ option.label }}</option>
 		</select>
 	</div>
 	<template v-for="(post, i) in allPosts" :key="i">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -8,14 +8,13 @@ const { data: allPosts } = await useFetch("/api/posts");
 const { data: allTags } = await useFetch("/api/tags");
 
 const tag = computed(() => route.query.tag);
-const selectedTag = ref(route.query.tag || '');
+const selectedTag = ref(route.query.tag || "");
 
-const tagOptions = computed(
-	(): { label: string; value: string }[] =>
-		[undefined, ...allTags.value].map((t) => ({
-			label: t || "未選択",
-			value: t || "",
-		})),
+const tagOptions = computed((): { label: string; value: string }[] =>
+	[undefined, ...allTags.value].map((t) => ({
+		label: t || "未選択",
+		value: t || "",
+	})),
 );
 
 function onChangeTag() {
@@ -26,9 +25,12 @@ function onChangeTag() {
 	});
 }
 
-watch(() => route.query.tag, (newTag) => {
-	selectedTag.value = newTag || '';
-});
+watch(
+	() => route.query.tag,
+	(newTag) => {
+		selectedTag.value = newTag || "";
+	},
+);
 
 useHead(() => ({
 	link: [


### PR DESCRIPTION
# Fix tag filter persistence on page reload

## Summary

Fixed an issue where the tag filtering dropdown would lose its selected state after page reload, even though the URL contained the correct tag query parameter and posts were filtered correctly. The root cause was improper Vue.js reactive data binding using `:selected` attributes instead of `v-model`.

**Key Changes:**
- Replaced `:selected` attribute approach with proper `v-model` binding on select element
- Added reactive `selectedTag` ref to track current selection state  
- Added route watcher to sync `selectedTag` with URL query parameter changes
- Simplified `tagOptions` computed property by removing redundant `selected` property

**Before:** Tag dropdown showed "未選択" after reload despite correct URL parameter
**After:** Tag dropdown correctly shows selected tag after reload and maintains proper filtering

## Review & Testing Checklist for Human

- [ ] **Test comprehensive tag filtering scenarios** - Try selecting different tags, reloading page, direct URL access with tag parameters
- [ ] **Verify existing tag link integration** - Click tag links from individual posts (in PostInfo component) and ensure they properly update the dropdown selection
- [ ] **Check for Vue.js console warnings** - Verify no reactive binding errors or warnings appear in browser console
- [ ] **Test edge cases** - Try invalid tag parameters in URL, empty tag states, special characters in tag names
- [ ] **End-to-end flow testing** - Navigate: homepage → select tag → reload → click post tag link → verify dropdown state throughout

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    IndexVue["app/pages/index.vue<br/>(Tag filtering logic)"]:::major-edit
    PostInfoVue["app/components/PostInfo.vue<br/>(Tag links in posts)"]:::context
    TagsAPI["server/api/tags/index.ts<br/>(Available tags endpoint)"]:::context
    PostsAPI["server/api/posts/index.ts<br/>(Posts data endpoint)"]:::context
    
    IndexVue --> TagsAPI
    IndexVue --> PostsAPI
    PostInfoVue --> IndexVue
    
    IndexVue --> Browser["Browser URL<br/>(Query parameters)"]:::context
    Browser --> IndexVue
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

### Notes

- **Tested locally** with development server - confirmed fix works for "雑記" and "投資" tags
- **Vue.js best practice** - Using `v-model` is the recommended approach for form element binding
- **No breaking changes** - All existing functionality preserved, only fixed the persistence issue
- **Session info** - Requested by Kazuhiro Kobayashi (@kzhrk) | [Link to Devin run](https://app.devin.ai/sessions/5a8799340f104bbfa149bfbd1ecff106)

![Tag selection before reload](/home/ubuntu/screenshots/localhost_3000_tag_231035.png)
![Tag selection persists after reload](/home/ubuntu/screenshots/localhost_3000_tag_231047.png)